### PR TITLE
Fix: shebang on windows

### DIFF
--- a/VideoSort.py
+++ b/VideoSort.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # VideoSort post-processing script for NZBGet.
 #


### PR DESCRIPTION
- revert the original shebang, as the latest version of nzbget works well with this shebang on POSIX systems