### PR TITLE
FIX: dated episode is identified as series

### DIFF
--- a/main.py
+++ b/main.py
@@ -1017,7 +1017,11 @@ def guess_info(filename):
         else:
             guess["vtype"] = "movie"
     elif guess["type"] == "episode":
-        guess["vtype"] = "series"
+        date = guess.get("date")
+        if date:
+            guess["vtype"] = "dated"
+        else:
+            guess["vtype"] = "series"
     else:
         guess["vtype"] = guess["type"]
 


### PR DESCRIPTION
Sometimes, an episode is identified  as series, even when it has a date in the filename.  This causes wrong filename to be created.

In case of a movie, there is a check if it contains a date, and if so it's marked as dated. This check doesn't exists in case of an episode, so this fix adds it.