### PR TITLE
Fix: Added channel 5 to streaming services in options.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Credits
 The script relies on python libraries:
 
 - [GuessIt 3.8.0](http://guessit.readthedocs.org) to extract information from file names and includes portions of code from [SABnzbd](https://sabnzbd.org/).
+    - [Patch 1](https://github.com/guessit-io/guessit/pull/799/commits/91b52758b24dac4944f21b5a04de830dd861689e) by [PDA-1](https://github.com/PDA-1) Added support for Channel 5 streaming service (My5)
 - [BabelFish 0.6.0](https://github.com/Diaoul/babelfish)
 - [ReBulk 3.2.0](https://github.com/Toilal/rebulk/)
 - [dateutil 2.8.2](https://github.com/dateutil/dateutil)

--- a/lib/guessit/config/options.json
+++ b/lib/guessit/config/options.json
@@ -658,6 +658,7 @@
         "ALL4",
         "4OD"
       ],
+      "Channel 5": "MY5",
       "CHRGD": "CHGD",
       "Cinemax": "CMAX",
       "Country Music Television": "CMT",

--- a/testdata.json
+++ b/testdata.json
@@ -137,6 +137,12 @@
     "NZBPO_SERIESFORMAT": "%sn/Season %s/%sn - S%0sE%0e - %en"
   },
   {
+    "id": "series-8",
+    "INPUTFILE": "Motorway.Cops.Catching.Britains.Speeders.S07E05.1080p.MY5.WEB-DL.AAC2.0.H.264-RAWR/Motorway.Cops.Catching.Britains.Speeders.S07E05.1080p.MY5.WEB-DL.AAC2.0.H.264-RAWR.mkv",
+    "OUTPUTFILE": "/series/Mkv/Motorway Cops Catching Britains Speeders/Season 7/Motorway_Cops_Catching_Britains_Speeders - S07E05 - 1080p.Web.mkv",
+    "NZBPO_SERIESFORMAT": "%Ext/%sn %y/Season %s/- %s_n - S%0sE%0e - %en - %qss.%qf.%ext"
+  },  
+  {
     "id": "dated-deprecated-t-1",
     "INPUTFILE": "The.Daily.Show.2013.06.27.Tom.Goldstein.HDTV.x264-FQM.mkv",
     "OUTPUTFILE": "/dated/2013-06/The Daily Show - 2013-6-27.mkv",


### PR DESCRIPTION
Channel 5 was missing from the list, it caused a wrong title name to be calculated.

I tried submitting a fix on the GuessIt project, but it seems no one is maintaining it recently.
https://github.com/guessit-io/guessit/pull/799

To test the fix, the file name "Motorway.Cops.Catching.Britains.Speeders.S07E05.1080p.MY5.WEB-DL.AAC2.0.H.264-RAWR/Motorway.Cops.Catching.Britains.Speeders.S07E05.1080p.MY5.WEB-DL.AAC2.0.H.264-RAWR.mkv" can be used.
It returns a wrong title name before the addition, and a correct one after it.