### PR TITLE
FIX: Videosort crushes with series name with 2 numbers and a dash

### DIFF
--- a/main.py
+++ b/main.py
@@ -957,7 +957,7 @@ def guess_info(filename):
     guess = guessit.api.guessit(
         unicode(guessfilename), {"allowed_languages": [], "allowed_countries": []}
     )
-    
+
     if verbose:
         print(guess)
 

--- a/main.py
+++ b/main.py
@@ -969,8 +969,8 @@ def guess_info(filename):
             if verbose:
                 print("use filename as title for recovery")
 
-    # workaround for titles with 2 numbers with a dash betwwen them (which guessit has problems with)
-    if isinstance(guess["title"], list):
+    # workaround for titles with 2 numbers with a dash between them (which guessit has problems with)
+    if "title" in guess and isinstance(guess["title"], list):
         guess["title"] = ' '.join(guess["title"])
     
     # fix some strange guessit guessing:

--- a/main.py
+++ b/main.py
@@ -957,7 +957,7 @@ def guess_info(filename):
     guess = guessit.api.guessit(
         unicode(guessfilename), {"allowed_languages": [], "allowed_countries": []}
     )
-
+    
     if verbose:
         print(guess)
 
@@ -969,6 +969,10 @@ def guess_info(filename):
             if verbose:
                 print("use filename as title for recovery")
 
+    # workaround for titles with 2 numbers with a dash betwwen them (which guessit has problems with)
+    if isinstance(guess["title"], list):
+        guess["title"] = ' '.join(guess["title"])
+    
     # fix some strange guessit guessing:
     # if guessit doesn't find a year in the file name it thinks it is episode,
     # but we prefer it to be handled as movie instead

--- a/testdata.json
+++ b/testdata.json
@@ -143,6 +143,12 @@
     "NZBPO_SERIESFORMAT": "%Ext/%sn %y/Season %s/- %s_n - S%0sE%0e - %en - %qss.%qf.%ext"
   },  
   {
+    "id": "series-9",
+    "INPUTFILE": "Airport.24-7.S01E08.1080p.Webrip.x264.AAC2.0-MasterCylinder/Airport.24-7.S01E08.1080p.Webrip.x264.AAC2.0-MasterCylinder.mkv",
+    "OUTPUTFILE": "/series/Mkv/Airport 24 7/Season 1/Airport 24 7 - S01E08 - 1080p.Web.mkv",
+    "NZBPO_SERIESFORMAT": "%Ext/%sn %y/Season %s/- %sn - S%0sE%0e - %en - %qss.%qf.%ext"
+  },  
+  {
     "id": "dated-deprecated-t-1",
     "INPUTFILE": "The.Daily.Show.2013.06.27.Tom.Goldstein.HDTV.x264-FQM.mkv",
     "OUTPUTFILE": "/dated/2013-06/The Daily Show - 2013-6-27.mkv",


### PR DESCRIPTION
Videosort crushes with series name with 2 numbers and a dash.
This is caused due to a list is returned from guessit (and not string) when such a case occur.
When a list is retuned then a string is expected, Videosort crushes with a TypeError error.

Since no one is maintaining guessit on github anymore, there is no point waiting for a fix from them,
I have created a workaround (similar to other guessit workarounds), that joins all the parts of the list into one string.
I have also added a test case to test it in future times. 