### PR TITLE
Fix: Added support for AV1 in filename

### DIFF
--- a/lib/guessit/config/options.json
+++ b/lib/guessit/config/options.json
@@ -169,6 +169,7 @@
         "3gp2",
         "asf",
         "avi",
+        "av1",
         "divx",
         "flv",
         "iso",

--- a/main.py
+++ b/main.py
@@ -957,7 +957,7 @@ def guess_info(filename):
     guess = guessit.api.guessit(
         unicode(guessfilename), {"allowed_languages": [], "allowed_countries": []}
     )
-    
+
     if verbose:
         print(guess)
 

--- a/main.py
+++ b/main.py
@@ -969,8 +969,8 @@ def guess_info(filename):
             if verbose:
                 print("use filename as title for recovery")
 
-    # workaround for titles with 2 numbers with a dash betwwen them (which guessit has problems with)
-    if isinstance(guess["title"], list):
+    # workaround for titles with 2 numbers with a dash between them (which guessit has problems with)
+    if "title" in guess and isinstance(guess["title"], list):
         guess["title"] = ' '.join(guess["title"])
     
     # fix some strange guessit guessing:

--- a/main.py
+++ b/main.py
@@ -957,7 +957,7 @@ def guess_info(filename):
     guess = guessit.api.guessit(
         unicode(guessfilename), {"allowed_languages": [], "allowed_countries": []}
     )
-
+    
     if verbose:
         print(guess)
 
@@ -969,6 +969,10 @@ def guess_info(filename):
             if verbose:
                 print("use filename as title for recovery")
 
+    # workaround for titles with 2 numbers with a dash betwwen them (which guessit has problems with)
+    if isinstance(guess["title"], list):
+        guess["title"] = ' '.join(guess["title"])
+    
     # fix some strange guessit guessing:
     # if guessit doesn't find a year in the file name it thinks it is episode,
     # but we prefer it to be handled as movie instead

--- a/testdata.json
+++ b/testdata.json
@@ -149,6 +149,12 @@
     "NZBPO_SERIESFORMAT": "%Ext/%sn %y/Season %s/- %sn - S%0sE%0e - %en - %qss.%qf.%ext"
   },  
   {
+    "id": "series-10",
+    "INPUTFILE": "Real.Time.with.Bill.Maher.S23E27.1080p.AV1.10bit-MeGusta/Real.Time.with.Bill.Maher.S23E27.1080p.AV1.10bit-MeGusta.mkv",
+    "OUTPUTFILE": "/series/Mkv/Real Time With Bill Maher/Season 23/Real Time With Bill Maher - S23E27 - 1080p.mkv",
+    "NZBPO_SERIESFORMAT": "%Ext/%sn %y/Season %s/- %sn - S%0sE%0e - %en - %qss.%qf.%ext"
+  },
+  {
     "id": "dated-deprecated-t-1",
     "INPUTFILE": "The.Daily.Show.2013.06.27.Tom.Goldstein.HDTV.x264-FQM.mkv",
     "OUTPUTFILE": "/dated/2013-06/The Daily Show - 2013-6-27.mkv",
@@ -219,3 +225,4 @@
     "NZBPO_EPISODESEPARATOR": "-E"
   }
 ]
+

--- a/testdata.json
+++ b/testdata.json
@@ -143,6 +143,12 @@
     "NZBPO_SERIESFORMAT": "%Ext/%sn %y/Season %s/- %s_n - S%0sE%0e - %en - %qss.%qf.%ext"
   },  
   {
+    "id": "series-9",
+    "INPUTFILE": "Airport.24-7.S01E08.1080p.Webrip.x264.AAC2.0-MasterCylinder/Airport.24-7.S01E08.1080p.Webrip.x264.AAC2.0-MasterCylinder.mkv",
+    "OUTPUTFILE": "/series/Mkv/Airport 24 7/Season 1/Airport 24 7 - S01E08 - 1080p.Web.mkv",
+    "NZBPO_SERIESFORMAT": "%Ext/%sn %y/Season %s/- %sn - S%0sE%0e - %en - %qss.%qf.%ext"
+  },  
+  {
     "id": "dated-deprecated-t-1",
     "INPUTFILE": "The.Daily.Show.2013.06.27.Tom.Goldstein.HDTV.x264-FQM.mkv",
     "OUTPUTFILE": "/dated/2013-06/The Daily Show - 2013-6-27.mkv",


### PR DESCRIPTION
Bug:
When the string "AV1" is in the filename, guessit recognizes it as the title of the show.

Fix:
- Added support for "AV1", in the guessit config file.
- Added test case for future verification.